### PR TITLE
fix(worker): Adds before_update hook

### DIFF
--- a/spacy_ray/worker.py
+++ b/spacy_ray/worker.py
@@ -185,6 +185,7 @@ class Worker:
             eval_frequency=self.T["eval_frequency"],
             exclude=self.T["frozen_components"],
             annotating_components=self.T["annotating_components"],
+            before_update=self.T["before_update"],
         )
         if self.rank == 0:
             print_row, finalize_logger = self.T["logger"](self.nlp)


### PR DESCRIPTION
Hi!

I found this repository on [spacy#8093](https://github.com/explosion/spaCy/issues/8093) and I was trying to train a large model in multiple GPUs.

I've tried using the latest Spacy version (3.5) with `spacy-transformers` and it seems this repo doesn't support it since the `training.before_update` key in the config is quite new (and required).

So, I've added it and I was able to launch a new training session with that change.